### PR TITLE
Java bytecode communication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ android.iml
 # Cocoapods
 #
 example/ios/Pods
+ios/Pods
 
 # node.js
 #

--- a/README.md
+++ b/README.md
@@ -71,6 +71,26 @@ EspIdfBleProvisioningRn.sendCustomData("custom-endpoint", "data").then(resp => {
     console.error(e)
 })
 
+// This method is used when is required to provision custom data to custom endpoints
+// with the special cavieat that React-Native's bridges to Native can destroy binary data
+// encoded as UTF-8 strings. See Example for details. Convert string to JS's Uint8Array, then to an array 
+// of strings where each string has the hexidecimal representation of its corresponding byte
+// there is a walk through in ./example/App.js
+EspIdfBleProvisioningRn.sendCustomDataWithByteData("custom-endpoint",["0", "FF", "52"]).then(resp => {
+    // this is worth tweaking, but I have found that the data response
+    // is wrapped in some other packaging I have to strip away from
+    // the beginning and then JSON parsing works. The Native Backend manages
+    // encryption at the session level. ESPRESSIF's libraries default to security_1 (as opposed to 0)
+    const data = JSON.parse(resp.data.substring(8));
+    ToastAndroid.show(
+        'Custom data with byte accuracy provisioned successfully',
+        ToastAndroid.LONG,
+    );
+    console.log(data); // data, likely in 
+}).catch(e => {
+    console.error(e)
+})
+
 // This method is used to provision new wifi credentials on the device
 EspIdfBleProvisioningRn.provisionNetwork("SSIS", "PASS").then(resp => {
     // resp will be {"success":true}

--- a/android/src/main/java/com/reactnativeespidfbleprovisioningrn/EspIdfBleProvisioningRnModule.java
+++ b/android/src/main/java/com/reactnativeespidfbleprovisioningrn/EspIdfBleProvisioningRnModule.java
@@ -325,7 +325,6 @@ public class EspIdfBleProvisioningRnModule extends ReactContextBaseJavaModule {
     byte[] output = new byte[length];
     for (int i = 0; i < length; i++)
         output[i] = (byte)Integer.parseInt(customData.getString(i), 16);
-    String string = new String(output);
     try {
       provisionManager.getEspDevice().sendDataToCustomEndPoint(customEndPoint,
         output,

--- a/example/App.js
+++ b/example/App.js
@@ -72,27 +72,94 @@ const App = () => {
 
     const provCustom = () => {
         EspIdfBleProvisioningRn.sendCustomData("custom-endpoint", "testinho").then(resp => {
-            ToastAndroid.show("Custom data provided with success", ToastAndroid.LONG)
+            ToastAndroid.show("Custom data provisioned successfully", ToastAndroid.LONG)
             console.log(resp)
         }).catch(e => {
-            ToastAndroid.show("Provide custom data error", ToastAndroid.LONG)
+            ToastAndroid.show("Provision Custom Data Error, " + e.getMessage(), ToastAndroid.LONG)
             console.log(e)
         })
     }
 
-    return (
-        <View style={{ justifyContent: 'space-around', flex: 1, padding: 10, alignContent: 'center' }}>
-            <Button title="SCAN Devices" onPress={scanFunc} />
-            <Text style={{ color: "white", textAlign: "center" }}>Service UUID: {uuid}</Text>
-            <Button title="Coonect to device" onPress={connectFun} />
-            <Button title="Set pop" onPress={setProof} />
-            <Button title="Get pop" onPress={getProof} />
-            <Text style={{ color: "white", textAlign: "center" }}>Pop: {pop}</Text>
-            <Button title="Scann networks" onPress={scanNetworks} />
-            <Button title="Prov creds" onPress={provCreds} />
-            <Button title="Prov custom data" onPress={provCustom} />
-        </View>
+  const provCustomWithByteData = () => {
+    // Often the strings communicating over BLE are really binary represented as UTF-8
+    // however UTF-16 is the react-native spec for strings
+    // These strings are usually generated with a cipher, perhaps protobuf (on npmjs)
+    // what's important is that React-Native is programmed in C. And C will trim trailing
+    // \x00 characters from strings. This has a big impact on BLE communication
+
+    // usually using Protocl Buffers, one would cmd.serializeBinary()
+    // which renders protcol buffer messages into binary wire format, a Uint8Array in JS
+    // const cmdContent = cmd.serializeBinary();
+    // however for demonstration let's start with a string with problematic trailing characters
+    const string = 'R\u0000';
+    console.log(string); // R�
+    // render string as Uint8Array, a typed array that represents an array of 8-bit unsigned integers
+    // this is the medium most common to protocol buffers
+    const strToBuf = str => {
+      var buf = new ArrayBuffer(str.length);
+      var bufView = new Uint8Array(buf);
+      for (let i = 0; i < str.length; i++) {
+        bufView[i] = str.charCodeAt(i);
+      }
+      return bufView;
+    };
+    const stringAsByteArray = strToBuf(string);
+    console.log(stringAsByteArray); // [82, 0] these numbers are in decimal, need to be hexi
+    // a Uint8Array in JS isn't exactly an array, more like {0: 82, 1:0} and yet there's more differences
+    // below converts the Uint8Array into a JS array of strings,
+    // each string is hexidecimal value of corresponding byte
+    const hexArrayOfCmdContent = Object.keys(stringAsByteArray).map(i =>
+      stringAsByteArray[i].toString(16),
     );
+    // using JSON.stringify below so it makes clear whether the values are strings or numbers
+    console.log('hexArrayOfCmdContent: ', JSON.stringify(hexArrayOfCmdContent)); // ["52", "0"]
+
+    EspIdfBleProvisioningRn.sendCustomDataWithByteData(
+      'custom-endpoint',
+      hexArrayOfCmdContent,
+    )
+      .then(resp => {
+        // this is worth tweaking, but I have found that the data response
+        // is wrapped in some other packaging I have to strip away from
+        // the beginning and then JSON parsing works. The Native Backend manages
+        // encryption at the session level
+        const data = JSON.parse(resp.data.substring(8));
+        ToastAndroid.show(
+          'Custom data with byte accuracy provisioned successfully',
+          ToastAndroid.LONG,
+        );
+        console.log(data);
+      })
+      .catch(e => {
+        console.log(e && e.message ? e.message : 'error querying live data');
+      });
+  };
+
+  return (
+    <View
+      style={{
+        justifyContent: 'space-around',
+        flex: 1,
+        padding: 10,
+        alignContent: 'center',
+      }}>
+      <Button title="Scan Devices" onPress={scanFunc} />
+      <Text style={{color: 'white', textAlign: 'center'}}>
+        Service UUID: {uuid}
+      </Text>
+      <Button title="Connect to Device" onPress={connectFun} />
+      <Button title="Set PoP" onPress={setProof} />
+      <Button title="Get PoP" onPress={getProof} />
+      <Text style={{color: 'white', textAlign: 'center'}}>Pop: {pop}</Text>
+      <Button title="Scan Networks" onPress={scanNetworks} />
+      <Button title="Provision WiFi Credentials" onPress={provCreds} />
+      <Button title="Provision Custom Data" onPress={provCustom} />
+      <Button
+        title="Provision Custom Data with Byte Information"
+        onPress={provCustomWithByteData}
+      />
+    </View>
+  );
 };
 
 export default App;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,6 +8,10 @@ interface EspIdfBleProvisioningRnType {
   connectToBLEDevice(uuid: string): Promise<Object>;
   scanNetworks(): Promise<Array<Object>>;
   sendCustomData(customEndPoint: string, customData: string): Promise<Object>;
+  sendCustomDataWithByteData(
+    customEndPoint: string,
+    customData: any // this must be an array of strings, where each string is a hexidecial value ie ["0", "FF", "52"] FF is max, unsigned
+  ): Promise<Object>;
   provisionNetwork(ssid: string, password: string): Promise<Object>;
 };
 


### PR DESCRIPTION
This PR adds a new Method that improves accuracy regarding communicating strings between React-Native and Java. The bridging mechanism sadly trims trailing null codes in strings and this mungs BLE communication data, which often are binary sequences represented as strings. 