### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -56,6 +56,6 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules
-    implementation "com.github.espressif:esp-idf-provisioning-android:lib-2.0.9"
+    implementation "com.github.espressif:esp-idf-provisioning-android:lib-2.1.2"
     implementation "org.greenrobot:eventbus:3.1.1"
 }


### PR DESCRIPTION
* What went wrong:
Could not determine the dependencies of task ':app:lintVitalPetronasstgRelease'.
> Could not resolve all artifacts for configuration ':app:productionDebugRuntimeClasspath'.
   > Could not find com.budiyev.android:code-scanner:2.1.0.
     Searched in the following locations:
       - https://repo.maven.apache.org/maven2/com/budiyev/android/code-scanner/2.1.0/code-scanner-2.1.0.pom
       - file:/Users/vagrant/.m2/repository/com/budiyev/android/code-scanner/2.1.0/code-scanner-2.1.0.pom
       - file:/Users/vagrant/git/node_modules/react-native/android/com/budiyev/android/code-scanner/2.1.0/code-scanner-2.1.0.pom
       - file:/Users/vagrant/git/node_modules/jsc-android/dist/com/budiyev/android/code-scanner/2.1.0/code-scanner-2.1.0.pom
       - https://jcenter.bintray.com/com/budiyev/android/code-scanner/2.1.0/code-scanner-2.1.0.pom
       - https://dl.google.com/dl/android/maven2/com/budiyev/android/code-scanner/2.1.0/code-scanner-2.1.0.pom
       - https://www.jitpack.io/com/budiyev/android/code-scanner/2.1.0/code-scanner-2.1.0.pom
     Required by:
         project :app > project :react-native-esp-idf-ble-provisioning-rn > com.github.espressif:esp-idf-provisioning-android:lib-2.0.9



com.github.espressif:esp-idf-provisioning-android:lib-2.0.9 is no more available